### PR TITLE
Add command-line executable 'opengraph'

### DIFF
--- a/bin/opengraph
+++ b/bin/opengraph
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+$:.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib/'))
+
+require 'json'
+require 'uri'
+require 'opengraph'
+
+url = ARGV[0]
+
+def usage
+	puts "\033[1mUsage: opengraph [url]\033[0m\n"
+	puts "Shows the Open Graph information of the given website, using the opengraph gem of Intridea Inc.\n"
+end
+
+
+if url.nil? || url.empty?
+	usage
+elsif url =~ /\A#{URI::regexp(['http', 'https'])}\z/
+	data = OpenGraph.fetch(url)
+    puts (data.nil? || data === false) ? "No (valid) Open Graph tags found." : JSON.pretty_generate(data)
+else
+	puts "Invalid url..."
+    exit 1
+end

--- a/opengraph.gemspec
+++ b/opengraph.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
      "Rakefile",
      "VERSION",
      "lib/opengraph.rb",
+     "bin/opengraph",
      "opengraph.gemspec",
      "spec/examples/partial.html",
      "spec/examples/rottentomatoes.html",
@@ -33,6 +34,7 @@ Gem::Specification.new do |s|
      "spec/spec_helper.rb"
   ]
   s.homepage = %q{http://github.com/intridea/opengraph}
+  s.executables = ["opengraph"]
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}


### PR DESCRIPTION
Usage on command prompt:
    opengraph [url]

Example:
```
opengraph http://www.rottentomatoes.com/m/1217700-kick_ass/
```

```json
{
  "title": "Kick-Ass",
  "type": "video.movie",
  "image": "http://resizing.flixster.com/iRqOt2b2Xy9YoBY4rmndNHFS720=/800x1200/dkpu1ddg7pbsk.cloudfront.net/movie/11/17/37/11173707_ori.jpg",
  "image:width": "800",
  "image:height": "1200",
  "url": "http://www.rottentomatoes.com/m/1217700-kick_ass/",
  "description": "Not for the faint of heart, Kick-Ass takes the comic adaptation genre to new levels of visual style, bloody violence, and gleeful profanity."
}
```